### PR TITLE
Fixed issue with arena screen not closing

### DIFF
--- a/src/scorekeeperScreen.py
+++ b/src/scorekeeperScreen.py
@@ -1,6 +1,7 @@
 import sys
 import updateLineup
 import postScreen
+import setupScreen
 from PyQt5.QtCore import *
 from PyQt5.QtGui import *
 from PyQt5.QtWidgets import *
@@ -262,8 +263,10 @@ class Window(QWidget):
 
     def activated1(self):
         self.orderSelect1.setCurrentIndex(1)
+
     def meetDone(self):
         self.close()
+        setupScreen.aScreen.close()  # grab instance of aScreen from setupScreen and close it
         self.pScreen = postScreen.Window()
         self.pScreen.show()
 

--- a/src/setupScreen.py
+++ b/src/setupScreen.py
@@ -136,9 +136,10 @@ class Window(QWidget):
     def doneClicked(self):
         self.close()
         self.sScreen = scorekeeperScreen.Window()
-        self.aScreen = arenaScreen.Window()
+        global aScreen  # make arena screen instance a global variable
+        aScreen = arenaScreen.Window()
         self.sScreen.show()
-        self.aScreen.show()
+        aScreen.show()
 
     def resetSelections(self):
         self.logoCheckbox.setChecked(False)


### PR DESCRIPTION
Made the arena screen instance a global variable so the scope is larger and not confined within the initial function. Then imported "setupScreen" to "scorekeeperScreen" and called the arena screen instance to close on the press of the 'Finish Meet' button.